### PR TITLE
Include message when attempting to nauta login via mobile data

### DIFF
--- a/lib/pages/connected_page.dart
+++ b/lib/pages/connected_page.dart
@@ -25,6 +25,7 @@ class _ConnectedPageState extends State<ConnectedPage> {
               title: Text(
                 widget.title,
                 style: TextStyle(fontWeight: FontWeight.bold),
+                textAlign: TextAlign.center,
               ),
             ),
             elevation: 0,

--- a/lib/pages/login_page.dart
+++ b/lib/pages/login_page.dart
@@ -265,6 +265,11 @@ class _LoginPageState extends State<LoginPage> {
 
     try {
       if (await NautaProtocol.isConnected()) {
+        var connectivityResult = await (new Connectivity().checkConnectivity());
+        var title = 'Conectado';
+        if (connectivityResult == ConnectivityResult.mobile){
+          title = 'Conectado via datos móviles';
+        }
         pr.style(message: 'Reconectando');
         await pr.show();
         await pr.hide();
@@ -273,7 +278,7 @@ class _LoginPageState extends State<LoginPage> {
           context,
           MaterialPageRoute(
             builder: (context) => ConnectedPage(
-              title: 'Conectado',
+              title: title,
               username: username,
             ),
           ),

--- a/lib/pages/login_page.dart
+++ b/lib/pages/login_page.dart
@@ -268,7 +268,7 @@ class _LoginPageState extends State<LoginPage> {
         var connectivityResult = await (new Connectivity().checkConnectivity());
         var title = 'Conectado';
         if (connectivityResult == ConnectivityResult.mobile){
-          title = 'Conectado via datos móviles';
+          title = 'Conectado vía datos móviles';
         }
         pr.style(message: 'Reconectando');
         await pr.show();


### PR DESCRIPTION
This PR changes the "Conectado" message with "Conectado via datos móviles" when a user attempts to use the nauta login using mobile data connection. 
This also horizontally center the message text.